### PR TITLE
Fix Granite 4.1 token metric names

### DIFF
--- a/ibm-granite/granite-4.1-8b/predict.py
+++ b/ibm-granite/granite-4.1-8b/predict.py
@@ -632,8 +632,8 @@ class Predictor(BasePredictor):
                 usage.total_tokens,
             )
             if not self._testing:
-                self.record_metric("input_token_count", usage.prompt_tokens)
-                self.record_metric("output_token_count", usage.completion_tokens)
+                self.record_metric("token_input_count", usage.prompt_tokens)
+                self.record_metric("token_output_count", usage.completion_tokens)
 
         logger.info("predict() complete")
 


### PR DESCRIPTION
## Summary
- Rename Granite 4.1 token usage metric keys to `token_input_count` and `token_output_count`.
- Keep the reported prompt/completion token values unchanged.

## Testing
- Verified with grep that `granite-4.1-8b/predict.py` uses the new metric keys.